### PR TITLE
Fixed Delta Odom updating with irregular contents

### DIFF
--- a/firmware/motor_control/differential_drive.h
+++ b/firmware/motor_control/differential_drive.h
@@ -126,8 +126,9 @@ inline void DifferentialDrive::updateState(float& delta_x_out, float& delta_y_ou
     left_motor_.setOutput(left_motor_output);
     right_motor_.setOutput(right_motor_output);
 
-    delta_x_out += distance_estimate * cos(delta_theta_out);
-    delta_y_out += distance_estimate * sin(delta_theta_out);
+    float estimated_theta = delta_theta_out + 0.5 * rotation_estimate;
+    delta_x_out += distance_estimate * cos(estimated_theta);
+    delta_y_out += distance_estimate * sin(estimated_theta);
     delta_theta_out += rotation_estimate;
 }
 

--- a/firmware/motor_control/differential_drive.h
+++ b/firmware/motor_control/differential_drive.h
@@ -41,7 +41,7 @@ private:
     MotorWithEncoder left_motor_;
     MotorWithEncoder right_motor_;
 
-    float update_period_ = 0.02f;
+    float update_period_ = 0.025f;
     float pulses_per_radian_ = 600.0f * 20.0f / 16.8f;
     float wheel_radius_ = 0.135f;
     float wheelbase_length_ = 0.45f;

--- a/firmware/motor_control/motor_control.ino
+++ b/firmware/motor_control/motor_control.ino
@@ -52,7 +52,7 @@ MotorCommand motorCommand;
 
 MotorWithEncoder leftMotor(leftMotorPwmPin, encoderLeftA, encoderLeftB, true);
 MotorWithEncoder rightMotor(rightMotorPwmPin, encoderRightA, encoderRightB, false);
-DifferentialDrive drivetrain(leftMotor, rightMotor, 0.02);
+DifferentialDrive drivetrain(leftMotor, rightMotor, 0.025);
 
 void configureCan();
 void printCanMsg();
@@ -123,6 +123,8 @@ void setup1(){
   conbus.addRegister(0x31, &collisonBoxDist);
 
   conbus.addRegister(0x40, &sendStatistics);
+
+  conbus.addRegister(0x50, &motor_updates_between_deltaodom);
 }
 void loop() {
   updateTimers();

--- a/firmware/motor_control/time.h
+++ b/firmware/motor_control/time.h
@@ -1,27 +1,9 @@
 #include "TickTwo.h"
 
+void setMotorUpdateFlag();
 
-void setFiveMilliSecFlag();
-void setTwentyMilliSecFlag();
-void setFiftyMilliSecFlag();
-void setFiveHundMilliSecFlag();
+bool MOTOR_UPDATE_FLAG = false;
 
-bool FIVE_MS_FLAG = false;   //TODO : flag to keep track of 5 ms flag
-bool TWENTY_MS_FLAG = false;    //TODO : flag to keep track of 20 ms flag
-bool FIFTY_MS_FLAG = false;  //TODO: flag to keep track of 50 ms flag
-bool FIVE_HUND_MS_FLAG = false;
-
-void setFiveMilliSecFlag() {
-  FIVE_MS_FLAG = true;
-}
-
-void setTwentyMilliSecFlag() {
-  TWENTY_MS_FLAG = true;
-}
-
-void setFiftyMilliSecFlag() {
-  FIFTY_MS_FLAG = true;
-}
-void setFiveHundMilliSecFlag() {
-  FIVE_HUND_MS_FLAG = true;
+void setMotorUpdateFlag() {
+  MOTOR_UPDATE_FLAG = true;
 }


### PR DESCRIPTION
- Delta odom now publishes onto the CAN bus after every 3 motor updates. This solves the issue of the delta odom publishing in the middle of two updates, resulting in strange aliasing of the output data.
- Updated the summed yaw estimate to use a trapezoidal sum